### PR TITLE
tasks/kibana.yml: Change path for ownership permissions change

### DIFF
--- a/tasks/kibana.yml
+++ b/tasks/kibana.yml
@@ -24,7 +24,7 @@
 
 - name: Kibana files ownership
   file:
-    path={{ elk_kibana.path }}
+    path=/opt/kibana-{{ elk_kibana.version }}
     state=directory
     owner={{ elk_nginx.user }} group={{ elk_nginx.user }} recurse=yes
   changed_when: False


### PR DESCRIPTION
Ownership permissions is now set on the extracted kibana path rather
than the linked path. Apply permissions to the symbolic link was
failing in Ubuntu 14.04. As the link is already being created with the
correct ownership, this achieves the same goal.
