### PR TITLE
Enable groovy scripting

### DIFF
--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -6,6 +6,10 @@
 # https://github.com/elasticsearch/elasticsearch/blob/master/config/elasticsearch.yml
 #
 
+############################## Scripting ######################################
+
+script.groovy.sandbox.enabled: true
+
 ############################## Network And HTTP ###############################
 
 {% if elk_elasticsearch.http.port is defined %}


### PR DESCRIPTION
Kibana requires groovy scripting to be enabled. Since the role uses the latest version of Elasticsearch (currently 1.4.4), it should be fine to enable groovy scripting (it was disabled by default in 1.4.3 due to vulnerabilities affecting this component, see http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html).
