### PR TITLE
New download paths for Kibana and configurable nginx port

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,12 +17,15 @@ elk_logstash:
   configs:
     - { src: logstash-simple.conf.j2, dest: simple.conf }
 elk_kibana:
-  version: 4.0.0-beta3
+  version: 4.0.2-linux-x64
   path: /opt/kibana
   port: 5601
   user: kibana
   password: kibana
   allowed_addresses:
     - 127.0.0.1
+
 elk_nginx:
+  port: 80
   user: nginx
+

--- a/tasks/kibana.yml
+++ b/tasks/kibana.yml
@@ -2,7 +2,7 @@
 - name: Kibana archive available
   get_url:
     dest=/opt
-    url=https://download.elasticsearch.org/kibana/kibana/kibana-{{ elk_kibana.version }}.tar.gz
+    url=https://download.elastic.co/kibana/kibana/kibana-{{ elk_kibana.version }}.tar.gz
     owner={{ elk_nginx.user }} group={{ elk_nginx.user }}
   sudo: yes
   register: new_archive_downloaded
@@ -53,7 +53,7 @@
     owner={{ elk_nginx.user }} group=root mode=400
   sudo: yes
   when: http_pass_gen|changed
-
+    
 - name: Nginx config file
   template:
     src=kibana-default.j2

--- a/templates/kibana-default.j2
+++ b/templates/kibana-default.j2
@@ -1,5 +1,5 @@
 server {
-  listen 80;
+  listen {{ elk_nginx.port }};
   server_name kibana;
   client_max_body_size 50M;
 

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -15,5 +15,3 @@ elk_java:
     - oracle-java7-set-default
   openjdk:
     - openjdk-7-jre-headless
-elk_nginx:
-  user: nginx


### PR DESCRIPTION
When trying to deploy this role I ran across two problems which I've addressed in this PR.
- The first one was that the download path for Kibana appears to have changed (at least for newer versions of Kibana). 
- Secondly, for my use case I needed to set the port for nginx to run on, and since `elk_nginx` was defined in `vars` I could not override it. Therefore I moved the config into defaults and added port as a config option.

I'm a novice with Ansible, so it might very well be that there are better ways of doing this, however I got this to work.

Thanks for providing a excellent role to setup the Elk-stack. It took me from zero to up and running in about a day. :smile: 
