### PR TITLE
Enable templating of logstash patterns.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,16 +6,20 @@ elk_java:
     - oracle-java7-set-default
   openjdk:
     - openjdk-7-jre-headless
+
 elk_elasticsearch:
   version: 1.4
   pid_file: /var/run/elasticsearch.pid
   http:
     port: 9200
+
 elk_logstash:
   version: 1.4
   pid_file: /var/run/logstash.pid
   configs:
     - { src: logstash-simple.conf.j2, dest: simple.conf }
+  patterns: [] # optional; follows same format as `configs`
+
 elk_kibana:
   version: 4.0.2-linux-x64
   path: /opt/kibana
@@ -28,4 +32,3 @@ elk_kibana:
 elk_nginx:
   port: 80
   user: nginx
-

--- a/tasks/logstash.yml
+++ b/tasks/logstash.yml
@@ -24,6 +24,16 @@
   sudo: yes
   notify: Restart logstash
 
+- name: Logstash pattern files
+  template:
+    src={{ item.src }}
+    dest=/opt/logstash/patterns/{{ item.dest }}
+    owner=root group=root mode=644
+  with_items: elk_logstash.patterns
+  sudo: yes
+  when: elk_logstash.patterns is defined
+  notify: Restart logstash
+
 - name: Make monit to look after Logstash
   template:
     src=logstash.monitrc.conf.j2


### PR DESCRIPTION
This change enables users to copy their custom logstash patterns with this role, rather than having to create that capability in their own role/playbook.
