### PR TITLE
openntpd install issues on ubuntu, see Issue #17

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
   apt: name=ntp state=absent purge=yes
   when: ansible_os_family == 'Debian'
   sudo: yes
-  
+
 - name: Install common apt packages
   apt: pkg={{ item }} state=latest update_cache=true
   with_items: elk_common_packages

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,11 @@
 - name: Include OS-specific variables
   include_vars: "{{ ansible_os_family }}.yml"
 
+- name: Work around bug ntp apparmor profile wrong cleanup
+  apt: name=ntp state=absent purge=yes
+  when: ansible_os_family == 'Debian'
+  sudo: yes
+  
 - name: Install common apt packages
   apt: pkg={{ item }} state=latest update_cache=true
   with_items: elk_common_packages


### PR DESCRIPTION
Openntpd package will not install correctly on ubuntu as it shares the same apparmor profile as the ntp package.

The issue is explained in Ubuntu bug 782116 (https://bugs.launchpad.net/ubuntu/+source/openntpd/+bug/782116)

Solution is to force purge the nap package from the system before installing openntpd
